### PR TITLE
Avoid shipping dev bin scripts

### DIFF
--- a/bai2.gemspec
+++ b/bai2.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.files = `git ls-files -z`.split("\x0")
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "bai2"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here


### PR DESCRIPTION
This gem doesn't provide any executables for invoking the library direct from a command line so we can remove the optional `executables` attribute from the gemspec. The `bin/` directory is useful for local development but doesn't need to be present on a gem user's system.